### PR TITLE
Add support for animated stickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ NOTE: You need a telegram bot token to make use of the script. You can easily ma
 
 ### Dependencies:
 
-- Webp converter library. (You can download the latest version from [here](https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html))
+- FFmpeg (You can download a recent build of ffmpeg [here](https://www.ffmpeg.org/download.html).)
 
-- Python 3.6 (Haven't tested for other Python 3 versions.)
+- Python 3.6+ (tested up to Python 3.12.)
 
 ### Usage:
 

--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ class StickerDownloader:
 
     def download_sticker_set(self, sticker_set):
         swd = assure_folder_exists(sticker_set['name'], root=self.cwd)
-        download_path = assure_folder_exists('webp', root=swd)
+        download_path = assure_folder_exists('source', root=swd)
         downloads = []
 
         print('Starting download of "{}" into {}'.format(sticker_set['name'], download_path))
@@ -137,17 +137,17 @@ class StickerDownloader:
 
     def convert_to_pngs(self, name):
         swd = assure_folder_exists(name, root=self.cwd)
-        webp_folder = assure_folder_exists('webp', root=swd)
-        png_folder = assure_folder_exists('png', root=swd)
+        source_folder = assure_folder_exists('source', root=swd)
+        dest_folder = assure_folder_exists('converted', root=swd)
 
-        webp_files = [os.path.join(webp_folder, i) for i in os.listdir(webp_folder)]
+        source_files = [os.path.join(source_folder, i) for i in os.listdir(source_folder)]
         png_files = []
 
         print('Converting stickers to pngs "{}"..'.format(name))
         start = time.time()
         with ThreadPoolExecutor(max_workers=self.THREADS) as executor:
-            futures = [executor.submit(self.convert_file, _input, os.path.join(png_folder, random_filename(6, 'png')))
-                       for _input in webp_files]
+            futures = [executor.submit(self.convert_file, _input, dest_folder)
+                       for _input in source_files]
             for i in as_completed(futures):
                 png_files.append(i.result())
 

--- a/main.py
+++ b/main.py
@@ -127,9 +127,9 @@ class StickerDownloader:
     def convert_file(_input, _output_folder):
         file_name = "/" + os.path.basename(_input)
         if _input[-4:] == 'webp':
-            command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "png")
-        if _input[-4:] == 'webm':
-            command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "gif")
+            command = 'ffmpeg -n -hide_banner -loglevel error -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "png")
+        elif _input[-4:] == 'webm':
+            command = 'ffmpeg -n -hide_banner -loglevel error -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "gif")
         else:
             print("Encountered an unknown file type. Copying as-is.")
             shutil.copy(_input, _output_folder)

--- a/main.py
+++ b/main.py
@@ -18,11 +18,6 @@ def assure_folder_exists(folder, root):
         os.mkdir(full_path)
     return full_path
 
-
-def random_filename(length, ext):
-    return ''.join([random.choice(string.ascii_lowercase) for _ in range(length)]) + '.{}'.format(ext)
-
-
 # TODO: Replace with a named tuple
 class File:
     def __init__(self, name, link):

--- a/main.py
+++ b/main.py
@@ -167,6 +167,8 @@ if __name__ == "__main__":
             break
         names.append(name.split('/')[-1])
 
+    names = list(set(names)) # Deduplicate URLs
+
     for sset in names:
         print('=' * 60)
         _ = downloader.get_sticker_set(sset)

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ class StickerDownloader:
         file_name = "/" + os.path.basename(_input)
         if _input[-4:] == 'webp':
             command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "png")
-        if _input[-4:] == 'webm':
+        elif _input[-4:] == 'webm':
             command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "gif")
         else:
             print("Encountered an unknown file type. Copying as-is.")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import shutil
 import requests
 import json
 import urllib.parse
@@ -5,8 +6,6 @@ from subprocess import check_output
 from concurrent.futures import as_completed, ThreadPoolExecutor
 import time
 import os
-import string
-import random
 
 TOKEN = ''
 
@@ -130,10 +129,17 @@ class StickerDownloader:
         return downloads
 
     @staticmethod
-    def convert_file(_input, _output):
-        command = 'dwebp -quiet "{}" -o "{}"'.format(_input, _output)
+    def convert_file(_input, _output_folder):
+        file_name = "/" + os.path.basename(_input)
+        if _input[-4:] == 'webp':
+            command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "png")
+        if _input[-4:] == 'webm':
+            command = 'ffmpeg -i "{}" "{}"'.format(_input, _output_folder + file_name[:-4] + "gif")
+        else:
+            print("Encountered an unknown file type. Copying as-is.")
+            shutil.copy(_input, _output_folder)
+            return
         check_output(command, shell=True)
-        return _output
 
     def convert_to_pngs(self, name):
         swd = assure_folder_exists(name, root=self.cwd)


### PR DESCRIPTION
This adds support for animated stickers. 
Animated stickers will be output in `gif` format.
This also makes it easy to add new file types in the future, should the need arise.

The output folders are renamed to reflect that the output file type is no longer guaranteed to be `png`.